### PR TITLE
Add tx receipt uniqueness check

### DIFF
--- a/x/xcvm/types/errors.go
+++ b/x/xcvm/types/errors.go
@@ -21,4 +21,6 @@ var (
 	ErrDestinationAddressMismatch = errorsmod.Register(ModuleName, 12, "destination address mismatch")
 	ErrSourceAddressMismatch      = errorsmod.Register(ModuleName, 13, "source address mismatch")
 	ErrAmountMismatch             = errorsmod.Register(ModuleName, 14, "amount mismatch")
+
+	ErrReceiptAlreadyProcessed = errorsmod.Register(ModuleName, 15, "receipt already processed")
 )

--- a/x/xcvm/types/keys.go
+++ b/x/xcvm/types/keys.go
@@ -1,6 +1,9 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"github.com/ethereum/go-ethereum/common"
+)
 
 const (
 	// ModuleName defines the module name
@@ -14,10 +17,16 @@ const (
 var (
 	TransferIntentIdKey            = []byte{0x00}
 	PendingTransferIntentKeyPrefix = []byte{0x01}
+	UsedReceiptKeyPrefix           = []byte{0x02}
 )
 
 func GetPendingTransferIntentKeyById(intentId uint64) []byte {
 	intentIdBz := make([]byte, 8)
 	binary.BigEndian.PutUint64(intentIdBz, intentId)
 	return append(PendingTransferIntentKeyPrefix, intentIdBz...)
+}
+
+func GetUsedReceiptKey(receiptHash []byte, blockHash common.Hash) []byte {
+	key := append(UsedReceiptKeyPrefix, receiptHash...)
+	return append(key, blockHash.Bytes()...)
 }


### PR DESCRIPTION
Prevents solver from being able to prove multiple intents with the same receipt. The combination of tx receipt hash and block hash is checked to ensure that it hasn't been used to fulfil any previous transfer intents.